### PR TITLE
Add support for Go Embed package

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,25 @@
+name: Go
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17
+
+    - name: Build
+      run: go build -v ./...
+
+    - name: Test
+      run: go test -v ./...

--- a/README.md
+++ b/README.md
@@ -55,5 +55,3 @@ $ ./electron-probe -inspect-target http://localhost:9229 -script scripts/dump_sl
 
 There is a small set of example scripts in the `scripts` directory to get you started.
 
-## TODO
-I plan to add support very soon for packing payload scripts into `electron-probe` at build time using the Go [embed](https://pkg.go.dev/embed) package so that they're not separate files.

--- a/electron-probe.go
+++ b/electron-probe.go
@@ -45,11 +45,11 @@ func main() {
 	devt := devtool.New(*inspectTarget)
 	pt, err := devt.Get(ctx, devtool.Node)
 	if err != nil {
-		panic(err)
+		log.Fatalf("Failed to identify DevTools listener of type Node: %v", err)
 	}
 	conn, err := rpcc.DialContext(ctx, pt.WebSocketDebuggerURL)
 	if err != nil {
-		panic(err)
+		log.Fatalf("Failed to establish websocket connection with CDP listener: %v", err)
 	}
 	defer conn.Close()
 	c := cdp.NewClient(conn)
@@ -59,7 +59,7 @@ func main() {
 	eval.ReplMode = BoolAddr(true)
 	reply, err := c.Runtime.Evaluate(context.Background(), eval)
 	if err != nil {
-		panic(err)
+		log.Fatalf("Script evaluation fatal error: %v", err)
 	}
 
 	if reply.ExceptionDetails != nil {

--- a/electron-probe.go
+++ b/electron-probe.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"context"
+	"embed"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"strconv"
 	"time"
@@ -14,6 +14,9 @@ import (
 	"github.com/mafredri/cdp/protocol/runtime"
 	"github.com/mafredri/cdp/rpcc"
 )
+
+//go:embed scripts/*
+var scriptFolder embed.FS
 
 // Working around a syntax limitation
 func BoolAddr(b bool) *bool {
@@ -32,7 +35,7 @@ func main() {
 		log.Fatalf("Must specify script payload")
 	}
 
-	scriptData, err := ioutil.ReadFile(*scriptPath)
+	scriptData, err := scriptFolder.ReadFile(*scriptPath)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Embedding scripts into the binary at build time. This makes it more convenient if you need to execute it on-target, you won't have to ship additional files. 